### PR TITLE
Fix default accessory name to be the same as in api.registerAccessory

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -9,7 +9,7 @@
         "title": "Name",
         "type": "string",
         "required": true,
-        "default": "Cooper&Hunter AC"
+        "default": "Cooper&HunterAC"
       },
       "model": {
         "title": "Model",


### PR DESCRIPTION
Without it HomeBridge says "No plugin was found for the accessory "Cooper&Hunter AC" in your config.json. Please make sure the corresponding plugin is installed correctly"